### PR TITLE
Add Survey Monkey Support

### DIFF
--- a/filter_lib.py
+++ b/filter_lib.py
@@ -1,0 +1,33 @@
+# filter_lib.py
+"""Jinja2 filters"""
+
+import re
+
+def j2_latex_filter(string):
+    """
+    Given a string it returns a string sanitized for use in a LaTeX document.
+
+    :param str string: string to execute replacements on
+    :rtype: str
+    """
+    replacements = {'#':r'\#',
+        '$':r'\$',
+        '%':r'\%',
+        '&':r'\&',           # r'\textampersand{}' someday?
+        r'~':r'\textasciitilde{}',
+        '_':r'\_',
+        '^':r'\textasciicircum{}',
+        '\\':r'\textbackslash{}',
+        '{':r'\{',
+        '}':r'\}',
+        }
+
+    print(replacements)
+
+    replacements =  dict((re.escape(k), v) for k, v in replacements.items())
+
+    print(replacements)
+
+    pattern = re.compile("|".join(replacements.keys()))
+
+    return pattern.sub(lambda match: replacements[re.escape(match.group(0))], string)

--- a/templates/report.tex.jinja
+++ b/templates/report.tex.jinja
@@ -19,11 +19,8 @@
 %\addtolength{\topmargin}{0.15in}
 
 \pagestyle{empty}
-\firstpageheadrule
-\firstpageheader{\LARGE{Evaluations - \VAR{course['term']} \VAR{course['year']} - \VAR{course['course']} Sec.\,\VAR{course['section']}}}{}{\LARGE{\VAR{course['teacher'][0]|first}.~\VAR{course['teacher'][1]}}}
-\runningheader{}{}{}
-\firstpagefooter{}{}{}
-\runningfooter{}{}{}
+\headrule
+\header{\LARGE{Evaluations - \VAR{course['term']} \VAR{course['year']} - \VAR{course['course']} Sec.\,\VAR{course['section']}}}{}{\LARGE{\VAR{course['teacher'][0]|first}.~\VAR{course['teacher'][1]}}}
 
 \newlength{\myrowskip}
 \setlength{\myrowskip}{12pt plus 4pt minus 4pt}
@@ -56,7 +53,7 @@ Students are given the following five options for responses to each survey quest
 
 \begin{center}
 \begin{xltabular}{\linewidth}{Xccr}\toprule
-\qquad\qquad\qquad \ \ Question & \ \ Summary \ \ & \ Frequencies (1 $\rightarrow$ 5) \  & \\
+\qquad\qquad\qquad \ \ Question & \ Summary \  & \ Frequencies (1 $\rightarrow$ 5) \  & \\
 \midrule\\ \endhead
 \bottomrule\endfoot
 
@@ -83,17 +80,24 @@ Students are given the following five options for responses to each survey quest
 \end{center}
 
 \BLOCK{ if questions_mc and questions_la -}
+\newpage
+\thispagestyle{head}
+
 \section*{Open answer questions}
+
+Students were given the opportunity to respond to each of the following questions.
+Responses were optional.
+
 %- for question in questions_la
 \subsection*{\VAR{question['text']}}
 \BLOCK{- if question['responses'] }
 \begin{itemize}
-%- for response in question['responses']
-\item \VAR{response}
+%- for comment in question['comments']
+\item \VAR{comment | escape_latex}
 %- endfor
 \end{itemize}
 \BLOCK{ else }
-No responses were recorded to this question
+No responses were recorded for this question.
 \BLOCK{ endif }
 %- endfor
 \BLOCK{- endif }


### PR DESCRIPTION
`evaluator3.py` now processes Survey Monkey data in summary format.  It:

* detects `.csv` files in subdirectories (of .)
* decides if the filename indicates course questionnaire data
* tests whether there is already an existing `.tex` file corresponding to that course
    - the output filename has been standardized on course parameters
* produces a `.tex` file if needed
    - the LaTeX code is defined in jinja2
    - the separate `.csv` files containing the responses to long answer questions are read, the responses are included in the tex file.
    - the long answer responses are escaped using a custom jinja filter.

TODO Tweak the tex output, test the processing, add support for SM non-summary data